### PR TITLE
How about a more structured format for welearnrc?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Welearn-bot
-This is a bot which lets you interact with WeLearn from the command line. It can 
+This is a bot which lets you interact with WeLearn from the command line. It can
 - Download all files/resources from multiple courses and organize them in designated folders.
 - List your assignments with details, or just your due assignments.
 
@@ -7,7 +7,13 @@ This is a bot which lets you interact with WeLearn from the command line. It can
 This script runs on python3, and requires the `requests` and `beautifulsoup4` libraries. Run `pip3 install requests bs4` to install them.
 
 ## Usage and configuration
-Create a file in your home folder called `.welearnrc`. Inside, put your username in the first line and your password in the second line.
+Create a file in your home folder called `.welearnrc`. Inside, add the following lines and will the `<>` placeholders with your details.
+
+```
+[setup]
+username = <your-username>
+password = <your-password>
+```
 
 Run `./welearn_bot.py -h` to get the following help message.
 ```
@@ -32,7 +38,7 @@ To get a list of available courses, run
 ```
 ./welearn_bot.py -l
 ```
-To pull all files from the courses AB1101 and XY5505, run 
+To pull all files from the courses AB1101 and XY5505, run
 ```
 ./welearn_bot.py AB1101 XY5505
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a bot which lets you interact with WeLearn from the command line. It can
 This script runs on python3, and requires the `requests` and `beautifulsoup4` libraries. Run `pip3 install requests bs4` to install them.
 
 ## Usage and configuration
-Create a file in your home folder called `.welearnrc`. Inside, add the following lines and will the `<>` placeholders with your details.
+Create a file in your home folder called `.welearnrc`. Inside, add the following lines and fill the `<>` placeholders with your details.
 
 ```
 [setup]

--- a/welearn_bot.py
+++ b/welearn_bot.py
@@ -2,6 +2,7 @@
 
 from requests import Session
 from bs4 import BeautifulSoup as bs
+from configparser import RawConfigParser
 import os, sys
 import argparse
 import urllib
@@ -22,12 +23,10 @@ if len(args.courses) == 0 and not args.listcourses:
 
 # Read the .welearnrc file from the home directory, and extract username and password
 configfile = os.path.expanduser("~/.welearnrc")
-username = ''
-password = ''
-with open(configfile, "r") as config:
-    lines = config.readlines()
-    username = lines[0].strip()
-    password = lines[1].strip()
+config = RawConfigParser()
+config.read(configfile)
+username = config.get("setup_settings", "username")
+password = config.get("setup_settings", "password")
 
 with Session() as s:
     # Login to WeLearn with supplied credentials
@@ -38,7 +37,7 @@ with Session() as s:
     s.post("https://welearn.iiserkol.ac.in/login/", login_data)
     home_page = s.get("https://welearn.iiserkol.ac.in/my/")
     home_content = bs(home_page.content, "html.parser")
-    
+
     # Build a list of courses and course page links
     courses_list = home_content.find("li", {"data-key": "mycourses"})
     course_links = courses_list.findAll("a", "list-group-item")
@@ -47,24 +46,24 @@ with Session() as s:
         course_url = course['href']
         course_name = course.find("span").contents[0]
         courses[course_name] = course_url
-    
+
     # If specified, only display the list of courses and exit
     if args.listcourses:
         for name in courses.keys():
             print(name)
         sys.exit()
-    
+
     # Read from a cache of links
     link_cache = set()
     if os.path.exists(".link_cache"):
         with open(".link_cache") as link_cache_file:
             for link in link_cache_file.readlines():
                 link_cache.add(link.strip())
-    
+
     # Select all courses if 'ALL' keyword is used
     if 'ALL' in map(str.upper, args.courses):
         args.courses = courses.keys()
-    
+
     # Loop through all given course IDs
     for selected_course_name in args.courses:
         # Ensure that the course name is valid
@@ -76,7 +75,7 @@ with Session() as s:
         selected_course_page = s.get(courses[selected_course_name])
         selected_course_content = bs(selected_course_page.content, "html.parser")
         links = selected_course_content.findAll('a', "aalink")
-        
+
         for link in links:
             # Skip cached links, unless --forcedownload
             if not args.forcedownload and link['href'] in link_cache:
@@ -86,7 +85,7 @@ with Session() as s:
                 if'/mod/assign/view.php' in link['href']:
                     assigment_page = s.get(link['href'])
                     assignment_content = bs(assigment_page.content, "html.parser")
-                    
+
                     topic = assignment_content.find("h2").text
                     intro = assignment_content.find("div", {"id": "intro"})
                     assignment_links = []
@@ -129,14 +128,14 @@ with Session() as s:
                 # Extract the file name and put the file in an appropriate directory
                 filename = urllib.parse.unquote(response.url.split("/")[-1])
                 filepath = os.path.join(selected_course_name, filename)
-                
+
                 # Skip embedded resources. Temporary fix
                 if filename.startswith("view.php"):
                     continue
-                
+
                 if not os.path.exists(selected_course_name):
                     os.makedirs(selected_course_name)
-                
+
                 with open(filepath, "wb") as download:
                     download.write(response.content)
 

--- a/welearn_bot.py
+++ b/welearn_bot.py
@@ -25,8 +25,8 @@ if len(args.courses) == 0 and not args.listcourses:
 configfile = os.path.expanduser("~/.welearnrc")
 config = RawConfigParser()
 config.read(configfile)
-username = config.get("setup_settings", "username")
-password = config.get("setup_settings", "password")
+username = config.get("setup", "username")
+password = config.get("setup", "password")
 
 with Session() as s:
     # Login to WeLearn with supplied credentials


### PR DESCRIPTION
## Why?
When we think of rc files, bashrc or vimrc, etc comes to our mind. They all have some variable-value kind of setup so that the meaning of each setting can be better conveyed to the user. I tried to achieve the same.

## How?
Python has a built-in `configparser` module that can parse `.ini` config files. So I chose to use `.ini` formatting for the `.welearnrc` file. This can then be easily parsed using the aforementioned module.

## Changes:
- Updated README.md to convey to the users to use the new format.
- Implemented `.welearnrc` parsing using the `configparser` module.

**NOTE:** Merging this into main will break the code until the user updated the `.weleanrc` file to use the new format.