### PR TITLE
Google calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,21 @@ PH2202
 CH3303
 LS4404
 ES5505
-
-[files]
-ignore = mp4,mkv
-pathprefix = ~/welearn
 ```
+
 You may omit any or all of your `[auth]` credentials, in which case you will be prompted each time you run the program.
 
 The `ALL` keyword will act as shorthand for the course names present in the `[courses]` section.
 This way, you can choose to omit redundant courses in this section.
 
-The `[files]` section lets you specify settings about the organization of your files.
+
+For more control over the organization of your files, add the `[files]` section to your config.
+```
+[files]
+ignore = mp4,mkv
+pathprefix = ~/welearn
+```
+
 All files with extensions listed in the `ignore` option will be not be downloaded.
 This is useful for ignoring typically large files such as video files.
 This setting is overridden by the `--ignoretypes` command line option, which in turn is overridden by the `--forcedownload` flag
@@ -55,10 +59,31 @@ The `pathprefix` is used to specify a common path for storing all your WeLearn c
 your resources and assignment files.
 This is overriden by the `--pathprefix` command line option.
 
+### Google calendar integration
+Integration with Google Calendar is completely optional. This feature allows you to save your assignment dates directly to Google Calendar, when you use the `--gcalendar` option.
+You will have to authenticate using OAuth2.0 - follow the given step.
+
+- Go to the [Google Cloud Console](https://console.cloud.google.com/), while logged in to your desired account. If you are new to the platform, you will be prompted to agree and continue.
+- Click on _Create Project_. Enter a suitable name, and leave the organization blank.
+- In the search bar, search for "Google Calendar API", and enable it.
+- Click on _Credentials_ > _Configure Consent Screen_
+- Click on _External_. Enter the "App Name", "User support email" and "Developer Contact Information" with your desired values. Click _Save and Continue_.
+- Fill in the "Test User's Email ID" with the address which you will be using to add events. Click _Save and Continue_ > _Back to Dashboard_.
+- In "API's & Services", click on _Credentials_ > _Create Credentials_. Set the Application type to "Desktop app", add the client name, and click _Create_. Upon being prompted, click _OK_.
+- In the "OAuth 2.0 Client ID's", click on the client name you just created. You'll see a page with "Client ID" and "Client secret" values 
+given on the right. Copy these and add the following lines to your config file (`.welearnrc` or `welearn.ini`), filling in your values.
+```
+[gcal]
+client_id = xxxxxxxxxxxxxxx.apps.googleusercontent.com
+client_secret = xxxxxxxxxxxxxxxxx
+```
+When you run the program using the `--gcalendar` option for the first time, you will be taken to an OAuth2.0 login page in your browser.
+You will stay logged in for at most a day.
+
 ## Usage
 Run `welearn_bot -h` to get the following help message.
 ```
-usage: welearn_bot [-h] [-d] [-i [IGNORETYPES ...]] [-f] [-p PATHPREFIX] action [courses ...]
+usage: welearn_bot [-h] [-d] [-c] [-i [IGNORETYPES ...]] [-f] [-p PATHPREFIX] action [courses ...]
 
 A command line client for interacting with WeLearn.
 
@@ -75,6 +100,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -d, --dueassignments  show only due assignments with the 'assignments' action
+  -c, --gcalendar       add due assignments to Google Calendar with the 'assignments' action
   -i [IGNORETYPES ...], --ignoretypes [IGNORETYPES ...]
                         ignores the specified extensions when downloading, overrides .welearnrc
   -f, --forcedownload   force download files even if already downloaded/ignored
@@ -114,6 +140,11 @@ Make sure that the `-d` flag comes first!
 To list all urls from the CH3303 course, run
 ```
 welearn_bot urls CH3303
+```
+### Calendar integration
+To list due assignments from all courses, and add them to your calendar, run
+```
+welearn_bot -dc assignments ALL
 ```
 ### Ignoring filetypes
 To download all resources from the course CH3303, ignoring pdf files, run

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ You will have to authenticate using OAuth2.0 - follow the given step.
 - Go to the [Google Cloud Console](https://console.cloud.google.com/), while logged in to your desired account. If you are new to the platform, you will be prompted to agree and continue.
 - Click on _Create Project_. Enter a suitable name, and leave the organization blank.
 - In the search bar, search for "Google Calendar API", and enable it.
-- Click on _Credentials_ > _Configure Consent Screen_
-- Click on _External_. Enter the "App Name", "User support email" and "Developer Contact Information" with your desired values. Click _Save and Continue_.
+- Click on _Credentials_ > _Configure Consent Screen_.
+- Choose _External_. Enter the "App Name", "User support email" and "Developer Contact Information" with your desired values. Click _Save and Continue_.
 - Fill in the "Test User's Email ID" with the address which you will be using to add events. Click _Save and Continue_ > _Back to Dashboard_.
-- In "API's & Services", click on _Credentials_ > _Create Credentials_. Set the Application type to "Desktop app", add a suitable client name, and click _Create_. Upon being prompted, click _OK_.
+- In "API's & Services", click on _Credentials_ > _Create Credentials_ > _OAuth client ID_. Set the Application type to "Desktop app", add a suitable client name, and click _Create_. Upon being prompted, click _OK_.
 - In the "OAuth 2.0 Client ID's", click on the client name you just created. You'll see a page with "Client ID" and "Client secret" values 
 given on the right. Copy these and add the following lines to your config file (`.welearnrc` or `welearn.ini`), filling in your values.
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You will have to authenticate using OAuth2.0 - follow the given step.
 - Click on _Credentials_ > _Configure Consent Screen_
 - Click on _External_. Enter the "App Name", "User support email" and "Developer Contact Information" with your desired values. Click _Save and Continue_.
 - Fill in the "Test User's Email ID" with the address which you will be using to add events. Click _Save and Continue_ > _Back to Dashboard_.
-- In "API's & Services", click on _Credentials_ > _Create Credentials_. Set the Application type to "Desktop app", add the client name, and click _Create_. Upon being prompted, click _OK_.
+- In "API's & Services", click on _Credentials_ > _Create Credentials_. Set the Application type to "Desktop app", add a suitable client name, and click _Create_. Upon being prompted, click _OK_.
 - In the "OAuth 2.0 Client ID's", click on the client name you just created. You'll see a page with "Client ID" and "Client secret" values 
 given on the right. Copy these and add the following lines to your config file (`.welearnrc` or `welearn.ini`), filling in your values.
 ```
@@ -79,6 +79,13 @@ client_secret = xxxxxxxxxxxxxxxxx
 ```
 When you run the program using the `--gcalendar` option for the first time, you will be taken to an OAuth2.0 login page in your browser.
 You will stay logged in for at most a day.
+
+If you want your events to be saved to a calendar other than your primary one, go to Google Calendar and create a new calendar.
+Once it appears under "My Calendars", open its settings, scroll down to "Integrate calendar" and copy the "Calendar ID".
+Update your config with this line under the `[gcal]` section.
+```
+calendar_id = c_xxxxxxxxxxxxxxxxxxxxxxxxxx@group.calendar.google.com
+```
 
 ## Usage
 Run `welearn_bot -h` to get the following help message.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests==2.24.0
+google_auth_oauthlib==0.4.4
 beautifulsoup4==4.9.3
+google_api_python_client==2.1.0
+protobuf==3.15.8

--- a/src/welearn_bot
+++ b/src/welearn_bot
@@ -3,6 +3,11 @@
 from moodlews.service import MoodleClient
 from moodlews.service import ServerFunctions
 
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+
 from bs4 import BeautifulSoup as bs
 from configparser import RawConfigParser
 from datetime import datetime
@@ -29,9 +34,10 @@ parser.add_argument("action", nargs=1, help="choose from\n\
 Abbreviations such as any one of 'f', 'a', 'u', 'c', 'w' are supported.")
 parser.add_argument("courses", nargs="*", help="IDs of the courses to download files from. The word ALL selects everything from the [courses] section in .welearnrc or welearn.ini")
 parser.add_argument("-d", "--dueassignments", action="store_true", help="show only due assignments with the 'assignments' action")
+parser.add_argument("-c", "--gcalendar", action="store_true", help="add due assignments to Google Calendar with the 'assignments' action")
 parser.add_argument("-i", "--ignoretypes", nargs="*", help="ignores the specified extensions when downloading, overrides .welearnrc")
 parser.add_argument("-f", "--forcedownload", action="store_true", help="force download files even if already downloaded/ignored")
-parser.add_argument("-p", "--pathprefix", nargs=1,  help="save the downloads to a custom path, overrides .welearnrc",)
+parser.add_argument("-p", "--pathprefix", nargs=1,  help="save the downloads to a custom path, overrides .welearnrc")
 
 args = parser.parse_args()
 
@@ -53,6 +59,9 @@ else:
 
 if args.dueassignments and action != "assignments":
     print("Can only use --dueassignments with 'assignments' action! Use the -h flag for usage.")
+    sys.exit(errno.EPERM)
+if args.gcalendar and action != "assignments":
+    print("Can only use --gcalendar with 'assignments' action! Use the -h flag for usage.")
     sys.exit(errno.EPERM)
 
 # Read the .welearnrc file from the home directory, and extract username and password
@@ -128,6 +137,42 @@ if args.pathprefix:
         print(prefix_path, "does not exist!")
         sys.exit(errno.ENOTDIR)
 
+# Read google calendar info from config
+if args.gcalendar:
+    try:
+        OAUTH_CLIENT_ID = config["gcal"]["client_id"]
+        OAUTH_CLIENT_SECRET = config["gcal"]["client_secret"]
+
+        gcal_client_config = {
+            "installed": {
+                "client_id": OAUTH_CLIENT_ID,
+                "client_secret": OAUTH_CLIENT_SECRET,
+                "redirect_uris": ["http://localhost", "urn:ietf:wg:oauth:2.0:oob"],
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://accounts.google.com/o/oauth2/token"
+            }
+        }
+    except KeyError:
+        print("Invalid configuration!")
+        sys.exit(errno.ENODATA)
+
+    # Connect to the Google Calendar API
+    SCOPES = ['https://www.googleapis.com/auth/calendar.events']
+    creds = None
+    gcal_token_path = os.path.expanduser("~/.gcal_token")
+    if os.path.exists(gcal_token_path):
+        creds = Credentials.from_authorized_user_file(gcal_token_path, SCOPES)
+    # If there are no valid credentials, login
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_config(gcal_client_config, SCOPES)
+            creds = flow.run_local_server(port=0)
+        # Save the credentials for the next run
+        with open(gcal_token_path, 'w') as gcal_token:
+            gcal_token.write(creds.to_json())
+    service = build('calendar', 'v3', credentials=creds)
 
 link_cache_filepath = os.path.join(prefix_path, ".link_cache")
 
@@ -145,8 +190,23 @@ def write_link_cache(link_cache):
         json.dump(link_cache, link_cache_file)
 
 
-# Login to WeLearn with supplied credentials
+event_cache_filepath = os.path.expanduser("~/.welearn_event_cache")
 
+# Read from a cache of events
+def read_event_cache():
+    event_cache = dict()
+    if os.path.exists(event_cache_filepath):
+        with open(event_cache_filepath) as event_cache_file:
+            event_cache = json.load(event_cache_file)
+    return event_cache
+
+# Update cached event
+def write_event_cache(event_cache):
+    with open(event_cache_filepath, "w") as event_cache_file:
+        json.dump(event_cache, event_cache_file)
+
+
+# Login to WeLearn with supplied credentials
 moodle = MoodleClient(baseurl)
 token = moodle.authenticate(username, password)
 if not token:
@@ -201,6 +261,28 @@ def get_courses_by_id():
             course_ids[course['id']] = course_name
     return course_ids
 
+def create_event(name, description, start, end, reminders=True):
+    newevent = {
+        'summary': name,
+        'location' : '',
+        'description' : description,
+        'start' : {
+            'dateTime' : start,
+            'timeZone' : 'Asia/Kolkata',
+        },
+        'end' : {
+            'dateTime' : end,
+            'timeZone' : 'Asia/Kolkata',
+        },
+        'reminders': {
+            'useDefault': reminders,
+            'overrides': [
+                {'method': 'popup', 'minutes': 10},
+            ],
+        },
+    }
+    return newevent
+
 
 if action == "whoami":
     # Get core user information
@@ -225,6 +307,8 @@ elif action == "courses":
 
 elif action == "assignments":
     link_cache = read_link_cache()
+    if args.gcalendar:
+        event_cache = read_event_cache()
     # Get assignment data from server
     assignments = moodle.server(ServerFunctions.ASSIGNMENTS)
 
@@ -237,6 +321,7 @@ elif action == "assignments":
         no_assignments = True
         for assignment in course['assignments']:
             # Get the assignment name, details, due date, and relative due date
+            assignment_id = assignment["id"]
             name = assignment['name']
             duedate = datetime.fromtimestamp(int(assignment['duedate']))
             due_str = duedate.strftime('%a %d %b, %Y, %H:%M:%S')
@@ -262,7 +347,7 @@ elif action == "assignments":
                 print(f"        Due on         : {due_str} ({duedelta_str} ago)")
 
             # Get submission details
-            submission = moodle.server(ServerFunctions.ASSIGNMENT_STATUS, assignid=assignment["id"])
+            submission = moodle.server(ServerFunctions.ASSIGNMENT_STATUS, assignid=assignment_id)
             submission_made = False
             for plugin in submission['lastattempt']['submission']['plugins']:
                 if plugin['name'] == "File submissions":
@@ -276,8 +361,35 @@ elif action == "assignments":
                                 print(f"        Submission     : {filename} ({submission_date_str})")
             if not submission_made:
                 print(f"        Submission     : NONE")
+
+            # Write event to calendar
+            if args.gcalendar and due:
+                # Put deadline at the *end* of the event
+                startdate = duedate - timedelta(hours = 1)
+                start_time = startdate.isoformat()
+                end_time = duedate.isoformat()
+                event_name = f"{course_name} - {name}"
+                if str(assignment_id) not in event_cache:
+                    # Create and push a new event
+                    event = create_event(event_name, detail, start_time, end_time, False)
+                    added_event = service.events().insert(calendarId='primary', body=event).execute()
+                    event_id = added_event['id']
+                    event_cache[assignment_id] = event_id
+                    print(f"        Added event to calendar.")
+                else:
+                    # Update event if necessary
+                    event = service.events().get(calendarId='primary', eventId=event_cache[str(assignment_id)]).execute()
+                    if event['start']['dateTime'] != (start_time + "+05:30"):
+                        event['start']['dateTime'] = start_time
+                        event['end']['dateTime'] = end_time
+                        updated_event = service.events().update(calendarId='primary', eventId=event['id'], body=event).execute()
+                        event_cache[assignment_id] = updated_event['id']
+                        print(f"        Updated event in calendar.")
             print()
+
     write_link_cache(link_cache)
+    if args.gcalendar:
+        write_event_cache(event_cache)
     sys.exit(0)
 
 elif action == "urls":

--- a/src/welearn_bot
+++ b/src/welearn_bot
@@ -156,6 +156,11 @@ if args.gcalendar:
         print("Invalid configuration!")
         sys.exit(errno.ENODATA)
 
+    try:
+        gcal_calendar_id = config["gcal"]["calendar_id"]
+    except KeyError:
+        gcal_calendar_id = "primary"
+
     # Connect to the Google Calendar API
     SCOPES = ['https://www.googleapis.com/auth/calendar.events']
     creds = None
@@ -372,17 +377,17 @@ elif action == "assignments":
                 if str(assignment_id) not in event_cache:
                     # Create and push a new event
                     event = create_event(event_name, detail, start_time, end_time, False)
-                    added_event = service.events().insert(calendarId='primary', body=event).execute()
+                    added_event = service.events().insert(calendarId=gcal_calendar_id, body=event).execute()
                     event_id = added_event['id']
                     event_cache[assignment_id] = event_id
                     print(f"        Added event to calendar.")
                 else:
                     # Update event if necessary
-                    event = service.events().get(calendarId='primary', eventId=event_cache[str(assignment_id)]).execute()
+                    event = service.events().get(calendarId=gcal_calendar_id, eventId=event_cache[str(assignment_id)]).execute()
                     if event['start']['dateTime'] != (start_time + "+05:30"):
                         event['start']['dateTime'] = start_time
                         event['end']['dateTime'] = end_time
-                        updated_event = service.events().update(calendarId='primary', eventId=event['id'], body=event).execute()
+                        updated_event = service.events().update(calendarId=gcal_calendar_id, eventId=event['id'], body=event).execute()
                         event_cache[assignment_id] = updated_event['id']
                         print(f"        Updated event in calendar.")
             print()


### PR DESCRIPTION
## Feature
This introduces the `--gcalendar` flag with the `assignments` action, which will add due assignments to the user's Google Calendar of choice. You can run
```
welearn_bot -dc assignments ALL
```
to add all due assignments to your Google Calendar, after appropriate configuration. 

The duration of the created event extends one hour **before** the deadline, up to the deadline. This choice was made so that the user gets some level of notification before the deadline, and because logically the event ought to end when the deadline is reached.

The user can also choose a "sub calendar" within their Google Calendar account to push events. This gives an additional layer of control, whereby calendarwide preferences such as event colour, notification settings, visibility/sharing, etc can be configured directly from Google Calendar.

Thanks to @AK6263 for contributing the base code for connecting the the Google Calendar API and pushing events.

## Caveats
Using this feature requires a fairly complicated process of authentication, which includes the creation of tokens from the Google Developer Console. Complete details are present in the updated README.md. In addition, the program triggers an OAuth login page which opens in the browser if the refresh token expires, which happens roughly every 7 days.

Since this particular feature cannot be automated to the same level as the other actions, Google Calendar integration has been kept as unintrusive and optional as possible.

## Changes
- The `--gcalendar` flag has been added, along with functionality for using the Google Calendar API via OAuth 2.0.
- The  `[gcal]` section has been added to the config file, which must have the `client_id` and `client_secret` keys for authenticating with the Google Calendar API.
- The optional `calendar_id` key specifies the particular calendar within Google Calendar to which events are to be added.