### PR TITLE
Fetch students' assignment submissions (TAs)

### DIFF
--- a/src/moodlews/service.py
+++ b/src/moodlews/service.py
@@ -2,6 +2,7 @@ from requests import Session
 import urllib.parse
 import json
 
+
 class ServerFunctions:
     SITE_INFO = "core_webservice_get_site_info"
     ALL_COURSES = "core_course_get_courses_by_field"
@@ -11,6 +12,9 @@ class ServerFunctions:
     ASSIGNMENT_STATUS = "mod_assign_get_submission_status"
     URLS = "mod_url_get_urls_by_courses"
     RESOURCES = "mod_resource_get_resources_by_courses"
+    COURSE_USERS = "core_enrol_get_enrolled_users"
+    SUBMISSION = "mod_assign_get_submission_status"
+
 
 class MoodleClient:
     def __init__(self, baseurl):

--- a/src/moodlews/service.py
+++ b/src/moodlews/service.py
@@ -40,7 +40,7 @@ class MoodleClient:
         except KeyError:
             return False
 
-    def server(self, function, **data):
+    def server(self, function, data={}):
         return self.response_json(
             self.server_url,
             wstoken=self.token,

--- a/src/welearnbot/__main__.py
+++ b/src/welearnbot/__main__.py
@@ -1,4 +1,4 @@
 from welearnbot import welearnbot
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     welearnbot.main()

--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -147,11 +147,7 @@ def handle_submissions(
 
     course_cache_filepath = os.path.join(prefix_path, COURSE_CACHE)
     courses_cache = utils.get_courses_cache(
-        moodle,
-        course_cache_filepath,
-        userid,
-        submission_config.keys(),
-        args.update_course_cache,
+        moodle, course_cache_filepath, userid, args.update_course_cache,
     )
 
     link_cache = utils.read_cache(link_cache_filepath)
@@ -172,7 +168,9 @@ def handle_submissions(
                 continue
         if "ALL" in rolls:
             rolls = sorted(courses_cache[course]["participants"].keys())
-        for assignment in courses_cache[course]["assignments"]:
+
+        assignments = utils.fetch_assignments(moodle, courses_cache[course]["id"])
+        for assignment in assignments:
             if assignment["duedate"] > time():
                 continue
             for roll in rolls:

--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -217,7 +217,7 @@ def handle_files(
                                 course_name,
                                 link_cache,
                                 token,
-                                subfolder=folder_name,
+                                subfolders=[folder_name],
                             )
                         )
 

--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -8,7 +8,12 @@ from datetime import datetime
 from moodlews.service import MoodleClient, ServerFunctions
 from welearnbot import resolvers
 from welearnbot.gcal import publish_gcal_event
-from welearnbot.utils import get_resource, read_cache, write_cache, show_file_statuses
+from welearnbot.utils import (
+    download_resource,
+    read_cache,
+    write_cache,
+    show_file_statuses,
+)
 
 
 def handle_whoami(moodle: MoodleClient) -> None:
@@ -75,7 +80,7 @@ def handle_assignments(
             for attachment in assignment["introattachments"]:
                 print(f"        Attachment     : {attachment['filename']}")
                 file_statuses.append(
-                    get_resource(
+                    download_resource(
                         args,
                         moodle,
                         ignore_types,
@@ -188,7 +193,7 @@ def handle_files(
                 if modname == "resource":
                     for resource in module["contents"]:
                         file_statuses.append(
-                            get_resource(
+                            download_resource(
                                 args,
                                 moodle,
                                 ignore_types,
@@ -203,7 +208,7 @@ def handle_files(
                     folder_name = module.get("name", "")
                     for resource in module["contents"]:
                         file_statuses.append(
-                            get_resource(
+                            download_resource(
                                 args,
                                 moodle,
                                 ignore_types,

--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -157,15 +157,19 @@ def handle_submissions(
     link_cache = utils.read_cache(link_cache_filepath)
     file_statuses = []
     for course in args.courses:
-        if course not in submission_config.keys():
-            print(f"No entry for {course} in the config under [submissions] section")
-            continue
         if course not in courses_cache:
             print(f"{course} is not a valid course id")
             continue
-        rolls = submission_config[course]
         if args.rolls:
             rolls = utils.get_rolls(",".join(args.rolls))
+        else:
+            try:
+                rolls = submission_config[course]
+            except KeyError:
+                print(
+                    f'Could not resolve roll numbers for {course}. Please add it in your config or use "-r" flag'
+                )
+                continue
         if "ALL" in rolls:
             rolls = sorted(courses_cache[course]["participants"].keys())
         for assignment in courses_cache[course]["assignments"]:

--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -22,7 +22,7 @@ def handle_courses(moodle: MoodleClient) -> None:
     userid = info["userid"]
 
     # Get enrolled courses information
-    courses = moodle.server(ServerFunctions.USER_COURSES, userid=userid)
+    courses = moodle.server(ServerFunctions.USER_COURSES, {"userid": userid})
     for course in courses:
         course_name = course["fullname"]
         star = " "
@@ -95,7 +95,7 @@ def handle_assignments(
 
             # Get submission details
             submission = moodle.server(
-                ServerFunctions.ASSIGNMENT_STATUS, assignid=assignment_id
+                ServerFunctions.ASSIGNMENT_STATUS, {"assignid": assignment_id}
             )
             submission_made = False
             try:
@@ -180,7 +180,7 @@ def handle_files(
     # Iterate through each course, and fetch all modules
     for courseid in course_ids:
         course_name = course_ids[courseid]
-        page = moodle.server(ServerFunctions.COURSE_CONTENTS, courseid=courseid)
+        page = moodle.server(ServerFunctions.COURSE_CONTENTS, {"courseid": courseid})
         for item in page:
             modules = item.get("modules", [])
             for module in modules:

--- a/src/welearnbot/constants.py
+++ b/src/welearnbot/constants.py
@@ -1,5 +1,6 @@
 BASEURL = "https://welearn.iiserkol.ac.in"
 LINK_CACHE = ".link_cache"
+COURSE_CACHE = ".course_cache"
 EVENT_CACHE = "~/.welearn_event_cache"
 ARCHIVE_TYPES = [
     "7Z",

--- a/src/welearnbot/constants.py
+++ b/src/welearnbot/constants.py
@@ -1,3 +1,11 @@
 BASEURL = "https://welearn.iiserkol.ac.in"
 LINK_CACHE = ".link_cache"
 EVENT_CACHE = "~/.welearn_event_cache"
+ARCHIVE_TYPES = [
+    "7Z",
+    "GZ",
+    "GZIP",
+    "TAR",
+    "TGZ",
+    "ZIP",
+]

--- a/src/welearnbot/gcal.py
+++ b/src/welearnbot/gcal.py
@@ -114,4 +114,3 @@ def publish_gcal_event(
             event_cache[assignment_id] = updated_event["id"]
             print(f"        Updated event in calendar.")
     write_cache(event_cache_filepath, event_cache)
-

--- a/src/welearnbot/parser.py
+++ b/src/welearnbot/parser.py
@@ -56,21 +56,27 @@ def setup_parser() -> ArgumentParser:
         help="roll numbers for which you want to download the submissions using the 'submissions' action",
     )
     parser.add_argument(
+        "-p",
+        "--pathprefix",
+        nargs=1,
+        help="save the downloads to a custom path, overrides .welearnrc",
+    )
+    parser.add_argument(
         "-f",
         "--forcedownload",
         action="store_true",
         help="force download files even if already downloaded/ignored",
     )
     parser.add_argument(
+        "-u",
+        "--update-course-cache",
+        action="store_true",
+        help="update course cache. Use this class when you change [submissions] section of config",
+    )
+    parser.add_argument(
         "-m",
         "--missingdownload",
         action="store_true",
         help="re-download those files which were downloaded earlier but deleted/moved from their location",
-    )
-    parser.add_argument(
-        "-p",
-        "--pathprefix",
-        nargs=1,
-        help="save the downloads to a custom path, overrides .welearnrc",
     )
     return parser

--- a/src/welearnbot/parser.py
+++ b/src/welearnbot/parser.py
@@ -14,15 +14,18 @@ def setup_parser() -> ArgumentParser:
         help="choose from\n\
     files       - downloads files/resources\n\
     assignments - lists assignments, downloads attachments\n\
+    submissions - lists submission count, downloads attachments\n\
     urls        - lists urls\n\
     courses     - lists enrolled courses\n\
     whoami      - shows the user's name and exits\n\
-    Abbreviations such as any one of 'f', 'a', 'u', 'c', 'w' are supported.",
+    Abbreviations such as any one of 'f', 'a', 's', 'u', 'c', 'w' are supported.",
     )
     parser.add_argument(
         "courses",
         nargs="*",
-        help="IDs of the courses to download files from. The word ALL selects everything \nfrom the [courses] section in .welearnrc or welearn.ini",
+        help="IDs of the courses to download files from. The word ALL selects all courses \n\
+    from [submissions] section in .welearnrc or welearn.ini for 'submissions' action\n\
+    from the [courses] section in .welearnrc or welearn.ini for all other action",
     )
     parser.add_argument("--version", action="version", version="1.2.4")
     parser.add_argument(

--- a/src/welearnbot/parser.py
+++ b/src/welearnbot/parser.py
@@ -26,10 +26,7 @@ def setup_parser() -> ArgumentParser:
     )
     parser.add_argument("--version", action="version", version="1.2.4")
     parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="show verbose warnings/errors",
+        "-v", "--verbose", action="store_true", help="show verbose warnings/errors",
     )
     parser.add_argument(
         "-d",

--- a/src/welearnbot/parser.py
+++ b/src/welearnbot/parser.py
@@ -50,6 +50,12 @@ def setup_parser() -> ArgumentParser:
         help="ignores the specified extensions when downloading, overrides .welearnrc",
     )
     parser.add_argument(
+        "-r",
+        "--rolls",
+        nargs="*",
+        help="roll numbers for which you want to download the submissions using the 'submissions' action",
+    )
+    parser.add_argument(
         "-f",
         "--forcedownload",
         action="store_true",

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -3,7 +3,7 @@ from welearnbot.utils import get_rolls
 
 from argparse import Namespace
 from configparser import RawConfigParser
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 import errno
 import getpass
@@ -86,7 +86,9 @@ def get_all_courses(config: RawConfigParser) -> List[str]:
     return all_courses
 
 
-def resolve_submission_details(config: RawConfigParser) -> None | dict[str, List[str]]:
+def resolve_submission_details(
+    config: RawConfigParser,
+) -> Optional[dict[str, List[str]]]:
     try:
         courses = dict(config["submissions"])
     except KeyError:

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -18,6 +18,8 @@ def resolve_action_mode(args: Namespace) -> str:
         action = "files"
     elif "assignments".startswith(args.action[0]):
         action = "assignments"
+    elif "submissions".startswith(args.action[0]):
+        action = "submissions"
     elif "urls".startswith(args.action[0]):
         action = "urls"
     elif "courses".startswith(args.action[0]):

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -1,4 +1,5 @@
 from moodlews.service import MoodleClient, ServerFunctions
+from welearnbot.utils import get_rolls
 
 from argparse import Namespace
 from configparser import RawConfigParser
@@ -81,6 +82,18 @@ def get_all_courses(config: RawConfigParser) -> List[str]:
     all_courses = map(str.upper, all_courses)
     all_courses = list(all_courses)
     return all_courses
+
+
+def resolve_submission_details(config: RawConfigParser) -> None | dict[str, List[str]]:
+    try:
+        courses = dict(config["submissions"])
+    except KeyError:
+        return
+
+    submission_courses = {}
+    for (key, val) in courses.items():
+        submission_courses[key.upper()] = get_rolls(val)
+    return submission_courses
 
 
 def resolve_ignore_types(config: RawConfigParser, args: Namespace) -> List[str]:

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -3,7 +3,7 @@ from welearnbot.utils import get_rolls
 
 from argparse import Namespace
 from configparser import RawConfigParser
-from typing import Optional, Tuple, List
+from typing import Tuple, List
 
 import errno
 import getpass
@@ -86,13 +86,13 @@ def get_all_courses(config: RawConfigParser) -> List[str]:
     return all_courses
 
 
-def resolve_submission_details(
-    config: RawConfigParser,
-) -> Optional[dict[str, List[str]]]:
+def resolve_submission_details(config: RawConfigParser,) -> dict[str, List[str]]:
     try:
         courses = dict(config["submissions"])
     except KeyError:
-        return
+        print("Invalid configuration!")
+        print("There is no field '[submissions]' in your config file")
+        sys.exit(errno.ENODATA)
 
     submission_courses = {}
     for (key, val) in courses.items():

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -74,6 +74,11 @@ def get_credentials(config: RawConfigParser) -> Tuple[str, str]:
     return username, password
 
 
+def get_userid(moodle: MoodleClient):
+    site_info = moodle.server(ServerFunctions.SITE_INFO)
+    return site_info["userid"]
+
+
 def get_all_courses(config: RawConfigParser) -> List[str]:
     """Also extract the list of `ALL` courses"""
     try:

--- a/src/welearnbot/resolvers.py
+++ b/src/welearnbot/resolvers.py
@@ -40,6 +40,11 @@ def resolve_action_mode(args: Namespace) -> str:
             "Can only use --gcalendar with 'assignments' action! Use the -h flag for usage."
         )
         sys.exit(errno.EPERM)
+    if args.rolls and action != "submissions":
+        print(
+            "Can only use --rolls with 'submission' action! Use the -h flag for usage."
+        )
+        sys.exit(errno.EPERM)
     return action
 
 

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -41,11 +41,11 @@ def create_event(
     return newevent
 
 
-def get_resource(
+def download_resource(
     args: Namespace,
     moodle: MoodleClient,
     ignore_types: List[str],
-    res: Any,
+    resource: Any,
     prefix: str,
     course: str,
     cache: dict,
@@ -54,19 +54,19 @@ def get_resource(
     indent: int = 0,
 ) -> Tuple[str, str]:
     """Helper function to retrieve a file/resource from the server"""
-    filename = res["filename"]
+    filename = resource["filename"]
     course_dir = os.path.join(prefix, course, subfolder)
-    fileurl = res["fileurl"]
+    fileurl = resource["fileurl"]
     _, extension = os.path.splitext(filename)
     extension = str.upper(extension[1:])
     if extension == "":
         # Missing extension - guess on the basis of the mimetype
-        extension = mimetypes.guess_extension(res["mimetype"])
+        extension = mimetypes.guess_extension(resource["mimetype"])
         filename += extension
         extension = extension[1:]
     filepath = os.path.join(course_dir, filename)
     short_filepath = os.path.join(course, subfolder, filename)
-    timemodified = int(res["timemodified"])
+    timemodified = int(resource["timemodified"])
 
     # Only download if forced, or not already downloaded
     if not args.forcedownload and fileurl in cache:

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -1,4 +1,5 @@
 from moodlews.service import MoodleClient
+from welearnbot.constants import ARCHIVE_TYPES
 
 from argparse import Namespace
 from typing import Any, Dict, List, Tuple
@@ -6,6 +7,7 @@ from typing import Any, Dict, List, Tuple
 import json
 import os
 import mimetypes
+import zipfile
 
 
 def read_cache(filepath: str) -> dict:
@@ -52,6 +54,7 @@ def download_resource(
     token: str,
     subfolders: List[str] = [],
     indent: int = 0,
+    extract: bool = True,
 ) -> Tuple[str, str]:
     """Helper function to retrieve a file/resource from the server"""
     filename = resource["filename"]
@@ -93,6 +96,13 @@ def download_resource(
     response = moodle.response(fileurl, token=token)
     with open(filepath, "wb") as download:
         download.write(response.content)
+
+    # TODO: add option whether to extract or not in the config and flag
+    if extension in ARCHIVE_TYPES and extract:
+        with zipfile.ZipFile(filepath, "r") as zip_ref:
+            zip_ref.extractall(course_dir)
+            print(" ... EXTRACTING", end="", flush=True)
+
     print(" ... DONE")
 
     # Add the file url to the cache

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -50,12 +50,12 @@ def download_resource(
     course: str,
     cache: dict,
     token: str,
-    subfolder: str = "",
+    subfolders: List[str] = [],
     indent: int = 0,
 ) -> Tuple[str, str]:
     """Helper function to retrieve a file/resource from the server"""
     filename = resource["filename"]
-    course_dir = os.path.join(prefix, course, subfolder)
+    course_dir = os.path.join(prefix, course, *subfolders)
     fileurl = resource["fileurl"]
     _, extension = os.path.splitext(filename)
     extension = str.upper(extension[1:])
@@ -65,7 +65,7 @@ def download_resource(
         filename += extension
         extension = extension[1:]
     filepath = os.path.join(course_dir, filename)
-    short_filepath = os.path.join(course, subfolder, filename)
+    short_filepath = os.path.join(course, *subfolders, filename)
     timemodified = int(resource["timemodified"])
 
     # Only download if forced, or not already downloaded

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -31,19 +31,11 @@ def create_event(
         "summary": name,
         "location": "",
         "description": description,
-        "start": {
-            "dateTime": start,
-            "timeZone": "Asia/Kolkata",
-        },
-        "end": {
-            "dateTime": end,
-            "timeZone": "Asia/Kolkata",
-        },
+        "start": {"dateTime": start, "timeZone": "Asia/Kolkata",},
+        "end": {"dateTime": end, "timeZone": "Asia/Kolkata",},
         "reminders": {
             "useDefault": reminders,
-            "overrides": [
-                {"method": "popup", "minutes": 10},
-            ],
+            "overrides": [{"method": "popup", "minutes": 10},],
         },
     }
     return newevent
@@ -96,9 +88,7 @@ def get_resource(
 
     # Download the file and write to the folder
     print(
-        " " * indent + "Downloading " + short_filepath,
-        end="",
-        flush=True,
+        " " * indent + "Downloading " + short_filepath, end="", flush=True,
     )
     response = moodle.response(fileurl, token=token)
     with open(filepath, "wb") as download:

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -33,7 +33,7 @@ def get_courses_cache(
     update_course_details: bool = False,
 ):
     cache = read_cache(course_cache_filepath)
-    if update_course_details:
+    if update_course_details or not cache:
         courses = moodle.server(ServerFunctions.USER_COURSES, {"userid": userid})
         for course in courses:
             courseid = course["shortname"]

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -172,4 +172,4 @@ def expand_dots(start: str, end: str):
         raise ValueError("Batch id before and after '...' does not match")
     start_roll = int(start[4:])
     end_roll = int(end[4:])
-    return [f"{batch}{roll}" for roll in range(start_roll + 1, end_roll)]
+    return [f"{batch}{roll:03}" for roll in range(start_roll + 1, end_roll)]

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -214,9 +214,10 @@ def show_file_statuses(file_statuses, verbose=False) -> None:
 
 
 def get_rolls(roll_string: str) -> List[str]:
+    roll_string = roll_string.strip().upper()
     if "ALL" in roll_string:
         return ["ALL"]
-    raw_rolls = roll_string.strip().upper().split(",")
+    raw_rolls = roll_string.split(",")
     rolls = []
     for i, roll in enumerate(raw_rolls):
         if roll == "...":

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -148,3 +148,28 @@ def show_file_statuses(file_statuses, verbose=False) -> None:
                         len(missing)
                     )
                 )
+
+
+def get_rolls(roll_string: str) -> List[str]:
+    if "ALL" in roll_string:
+        return ["ALL"]
+    raw_rolls = roll_string.strip().upper().split(",")
+    rolls = []
+    for i, roll in enumerate(raw_rolls):
+        if roll == "...":
+            rolls.extend(expand_dots(raw_rolls[i - 1], raw_rolls[i + 1]))
+        else:
+            rolls.append(roll)
+    return rolls
+
+
+def expand_dots(start: str, end: str):
+    """
+    Gives roll nos. between `start` and `end`
+    """
+    batch = start[:4]
+    if batch != end[:4]:
+        raise ValueError("Batch id before and after '...' does not match")
+    start_roll = int(start[4:])
+    end_roll = int(end[4:])
+    return [f"{batch}{roll}" for roll in range(start_roll + 1, end_roll)]

--- a/src/welearnbot/welearnbot.py
+++ b/src/welearnbot/welearnbot.py
@@ -63,6 +63,18 @@ def main():
             args, config, moodle, ignore_types, prefix_path, link_cache_filepath, token
         )
 
+    elif action == "submissions":
+        handler.handle_submissions(
+            args,
+            moodle,
+            course_cache,
+            submission_config,
+            ignore_types,
+            prefix_path,
+            link_cache_filepath,
+            token,
+        )
+
     elif action == "urls":
         handler.handle_urls(args, moodle)
 

--- a/src/welearnbot/welearnbot.py
+++ b/src/welearnbot/welearnbot.py
@@ -22,6 +22,15 @@ def main():
     config = resolvers.get_config()
     username, password = resolvers.get_credentials(config)
 
+    # Login to WeLearn with supplied credentials
+    moodle = MoodleClient(BASEURL)
+    token = moodle.authenticate(username, password)
+    if not token:
+        print("Invalid credentials!")
+        sys.exit(errno.EACCES)
+
+    userid = resolvers.get_userid(moodle)
+
     # Select all courses from config if `ALL` keyword is used
     if "ALL" in map(str.upper, args.courses):
         args.courses = resolvers.get_all_courses(config)
@@ -29,12 +38,8 @@ def main():
     ignore_types = resolvers.resolve_ignore_types(config, args)
 
     prefix_path = resolvers.resolve_prefix_path(config, args)
-    # Login to WeLearn with supplied credentials
-    moodle = MoodleClient(BASEURL)
-    token = moodle.authenticate(username, password)
-    if not token:
-        print("Invalid credentials!")
-        sys.exit(errno.EACCES)
+
+    submission_config = resolvers.resolve_submission_details(config)
 
     # Store cache file paths
     link_cache_filepath = os.path.join(prefix_path, LINK_CACHE)

--- a/src/welearnbot/welearnbot.py
+++ b/src/welearnbot/welearnbot.py
@@ -32,7 +32,7 @@ def main():
     # Select all courses from config if `ALL` keyword is used
     if "ALL" in map(str.upper, args.courses):
         if action == "submissions":
-            args.courses = list(resolvers.resolve_submission_details().keys())
+            args.courses = list(resolvers.resolve_submission_details(config).keys())
         else:
             args.courses = resolvers.get_all_courses(config)
 

--- a/src/welearnbot/welearnbot.py
+++ b/src/welearnbot/welearnbot.py
@@ -4,8 +4,9 @@ from moodlews.service import MoodleClient
 
 import welearnbot.action_handlers as handler
 from welearnbot import resolvers
-from welearnbot.constants import BASEURL, LINK_CACHE
+from welearnbot.constants import BASEURL, COURSE_CACHE, LINK_CACHE
 from welearnbot.parser import setup_parser
+from welearnbot.utils import construct_course_cache, read_cache
 
 import errno
 import os
@@ -43,6 +44,12 @@ def main():
 
     # Store cache file paths
     link_cache_filepath = os.path.join(prefix_path, LINK_CACHE)
+    course_cache_filepath = os.path.join(prefix_path, COURSE_CACHE)
+    course_cache = read_cache(course_cache_filepath)
+    if not course_cache:
+        course_cache = construct_course_cache(
+            moodle, course_cache_filepath, userid, submission_config
+        )
 
     # Action picker
     if action == "whoami":

--- a/src/welearnbot/welearnbot.py
+++ b/src/welearnbot/welearnbot.py
@@ -31,7 +31,10 @@ def main():
 
     # Select all courses from config if `ALL` keyword is used
     if "ALL" in map(str.upper, args.courses):
-        args.courses = resolvers.get_all_courses(config)
+        if action == "submissions":
+            args.courses = list(resolvers.resolve_submission_details().keys())
+        else:
+            args.courses = resolvers.get_all_courses(config)
 
     ignore_types = resolvers.resolve_ignore_types(config, args)
 


### PR DESCRIPTION
# Feature for TAs
This PR adds the capability for TAs to fetch assignment submissions from welearn.

### Notable features
- The assignments for each subject are downloaded into it's own `submissions` folder.
- Each student has it's own folder for each assignment.
- If the assignment are in archived form (compressed), they are automatically uncompressed.

### Config changes
The users will have to add a `[submissions]` section to their config with the appropriate information (as shown below)

```
[submissions]
CS1103 = ALL
CS1101 = 21MS020, ... , 21MS120
CS1102 = 21MS120,  21MS121,  21MS122,  21MS123,  21MS124,  21MS125,  21MS126
CS1101 = 20MS011,  19MS112, 21MS020, ... , 21MS120
```
**Note** that you have to add key value pairs of courseid and the roll numbers for which to fetch the submissions
The roll numbers can be entered in the following form:
- `ALL` to fetch all submissions
- a range of roll numbers
- a explicit list of roll numbes
- a mix of range and explicit roll numbers

### CLI arguments
- An additional action, `s (submissions)` has been exposed to the users for using this feature
- The users can also specify list of roll numbers from the cli using `-r (--rolls)` option
- CLI arguments override the config settings

### Misc
A new cache for course information is also added. The users can update the cache using the `-u` flag