### PR TITLE
Fixing attribute error

### DIFF
--- a/src/welearnbot/action_handlers.py
+++ b/src/welearnbot/action_handlers.py
@@ -182,7 +182,10 @@ def handle_files(
         course_name = course_ids[courseid]
         page = moodle.server(ServerFunctions.COURSE_CONTENTS, courseid=courseid)
         for item in page:
-            modules = item.get("modules", [])
+            try:
+                modules = item.get("modules", [])
+            except AttributeError:
+                pass
             for module in modules:
                 modname = module.get("modname", "")
                 if modname == "resource":


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/parth/.local/bin/welearn_bot", line 8, in <module>
    sys.exit(main())
  File "/home/parth/.local/lib/python3.8/site-packages/welearnbot/welearnbot.py", line 58, in main
    handler.handle_files(
  File "/home/parth/.local/lib/python3.8/site-packages/welearnbot/action_handlers.py", line 185, in handle_files
    modules = item.get("modules", [])
AttributeError: 'str' object has no attribute 'get'