### PR TITLE
fixed issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author = "Parth Bibekar",
     author_email = "bibekarparth24@gmail.com",
     url = "https://github.com/ParthBibekar/Welearn-bot",
-    version = "1.2.5",
+    version = "1.3.0",
     license = "MIT",
     package_dir = {"": "src"},
     packages=setuptools.find_packages(where="src"),

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -111,6 +111,8 @@ def download_resource(
 ) -> Tuple[str, str]:
     """Helper function to retrieve a file/resource from the server"""
     filename = resource["filename"]
+    for i in range(len(subfolders)):
+        subfolders[i] = subfolders[i].strip()
     course_dir = os.path.join(prefix, course, *subfolders)
     fileurl = resource["fileurl"]
     _, extension = os.path.splitext(filename)

--- a/src/welearnbot/utils.py
+++ b/src/welearnbot/utils.py
@@ -111,8 +111,7 @@ def download_resource(
 ) -> Tuple[str, str]:
     """Helper function to retrieve a file/resource from the server"""
     filename = resource["filename"]
-    for i in range(len(subfolders)):
-        subfolders[i] = subfolders[i].strip()
+    subfolders = [subfolder.strip() for subfolder in subfolders]
     course_dir = os.path.join(prefix, course, *subfolders)
     fileurl = resource["fileurl"]
     _, extension = os.path.splitext(filename)


### PR DESCRIPTION
# Fixed an Issue

## ISSUE 
When downloading files on windows, the bot throws an error during the download due to trailing spaces in the course subfolder names. 

[screenshot](https://imgur.com/a/YAhTIct)

## How to Reproduce the Issue
 Try to download files in which the subfolder name has trailing spaces. In Linux it doesn't throw any errors, since its allowed to have trailing spaces in filenames.

I've fixed the issue, by stripping the filename before creating the filepath in src/welearnbot/utils.py